### PR TITLE
Testes para classe get_route

### DIFF
--- a/backend/adapters/route_stop_repository_impl.py
+++ b/backend/adapters/route_stop_repository_impl.py
@@ -10,3 +10,13 @@ class RouteStopRepositoryImpl:
         with self.conn as connection:
             all_stops_in_route = connection.session.query(RouteStop).filter_by(route_id=route_id).all()
         return all_stops_in_route
+
+    def return_all_routes_from_stop_impl(self, stop_id):
+        with self.conn as connection:
+            all_routes_from_stop = connection.session.query(RouteStop).filter_by(stop_id=stop_id).all()
+        return all_routes_from_stop
+      
+    def return_route_stop_by_id_impl(self, stop_id, route_id):
+        with self.conn as connection:
+            route_stop = connection.session.query(RouteStop).filter_by(stop_id=stop_id, route_id=route_id).first()
+        return route_stop

--- a/backend/adapters/routes_repository_impl.py
+++ b/backend/adapters/routes_repository_impl.py
@@ -1,6 +1,5 @@
 from backend.database.models.bus_departures import BusDepartures
 from backend.database.config.db_connection import DBConnection
-from backend.database.models.route_stop import RouteStop
 from backend.database.models.routes import Routes
 from backend.database.models.routes_conversion import RoutesConversion
 
@@ -8,16 +7,6 @@ class RoutesRepositoryImpl:
     
     def __init__(self):
         self.conn = DBConnection()
-
-    def return_all_routes_from_stop_impl(self, stop_id):
-        with self.conn as connection:
-            all_routes_from_stop = connection.session.query(RouteStop).filter_by(stop_id=stop_id).all()
-        return all_routes_from_stop
-      
-    def return_route_stop_by_id_impl(self, stop_id, route_id):
-        with self.conn as connection:
-            route_stop = connection.session.query(RouteStop).filter_by(stop_id=stop_id, route_id=route_id).first()
-        return route_stop
     
     def return_trips_from_route_impl(self, route_id):
         with self.conn as connection:

--- a/backend/domain/repositories/route_stop_repository.py
+++ b/backend/domain/repositories/route_stop_repository.py
@@ -9,3 +9,9 @@ class RouteStopRepository:
 
     def return_all_stops_in_route(self, route_id):
         return self.repo.return_all_stops_in_route_impl(route_id)
+
+    def return_all_routes_from_stop(self, stop_id):
+        return self.repo.return_all_routes_from_stop_impl(stop_id)
+      
+    def return_route_stop_by_id(self, stop_id, route_id):
+        return self.repo.return_route_stop_by_id_impl(stop_id, route_id)

--- a/backend/domain/repositories/routes_repository.py
+++ b/backend/domain/repositories/routes_repository.py
@@ -7,12 +7,6 @@ class RoutesRepository:
             self.repo = RoutesRepositoryImpl()
         else:
             self.repo = repo
-
-    def return_all_routes_from_stop(self, stop_id):
-        return self.repo.return_all_routes_from_stop_impl(stop_id)
-      
-    def return_route_stop_by_id(self, stop_id, route_id):
-        return self.repo.return_route_stop_by_id_impl(stop_id, route_id)
     
     def return_trips_from_route(self, route_id):
         return self.repo.return_trips_from_route_impl(route_id)

--- a/backend/domain/route/bus_schedule_impl.py
+++ b/backend/domain/route/bus_schedule_impl.py
@@ -1,4 +1,5 @@
 from backend.domain.repositories.routes_repository import RoutesRepository
+from backend.domain.repositories.route_stop_repository import RouteStopRepository
 
 import datetime
 
@@ -6,14 +7,19 @@ MEAN_BUS_VELOCITY = 4.7  # velocity in m/s
 
 class BusScheduleImpl:
 
-    def __init__(self, routes_repo=None):
+    def __init__(self, routes_repo=None, route_stop_repo=None):
         if(routes_repo is None):
             self.routes_repo = RoutesRepository()
         else:
             self.routes_repo = routes_repo
 
+        if(route_stop_repo is None):
+            self.route_stop_repo = RouteStopRepository()
+        else:
+            self.route_stop_repo = route_stop_repo
+
     def get_travel_time_timedelta(self, stop_id, route_id):
-        route_stop = self.routes_repo.return_route_stop_by_id(stop_id, route_id)
+        route_stop = self.route_stop_repo.return_route_stop_by_id(stop_id, route_id)
         if not route_stop.traveled_time: 
             travel_time = route_stop.traveled_dist / MEAN_BUS_VELOCITY
         else:

--- a/backend/domain/route/get_route_impl.py
+++ b/backend/domain/route/get_route_impl.py
@@ -1,17 +1,23 @@
 from backend.domain.repositories.routes_repository import RoutesRepository
+from backend.domain.repositories.route_stop_repository import RouteStopRepository
 from backend.domain.route.route import Route
 
 class GetRouteImpl:
 
-    def __init__(self, routes_repo=None):
+    def __init__(self, routes_repo=None, route_stop_repo=None):
         if(routes_repo is None):
             self.routes_repo = RoutesRepository()
         else:
             self.routes_repo = routes_repo
 
+        if(route_stop_repo is None):
+            self.route_stop_repo = RouteStopRepository()
+        else:
+            self.route_stop_repo = route_stop_repo
+
     def get_routes_from_stop_impl(self, stop_id):
         stop_routes_list = []
-        all_routes_from_stop = self.routes_repo.return_all_routes_from_stop(stop_id)
+        all_routes_from_stop = self.route_stop_repo.return_all_routes_from_stop(stop_id)
         for entry in all_routes_from_stop:
             route = self.routes_repo.return_one_route_by_id(entry.route_id)
             stop_routes_list.append([entry.route_stop_id, Route(entry.route_id, route.route_short_name)])

--- a/backend/tests/mock/route_stop_repository_mock.py
+++ b/backend/tests/mock/route_stop_repository_mock.py
@@ -1,3 +1,4 @@
+from backend.database.models.routes import Routes
 from backend.domain.route_stop.route_stop import RouteStop
 
 class RouteStopRepositoryMock:
@@ -8,5 +9,16 @@ class RouteStopRepositoryMock:
                 RouteStop('609-03', 1, None, 0.0, 18568, '10100130600640'),
                 RouteStop('609-03', 1, None, 0.0, 18568, '10100446100580')
             ]
-        else:
-            return 'Invalid Route ID'
+        return 'Invalid Route ID'
+
+    def return_all_routes_from_stop_impl(self, stop_id):
+        if(stop_id == '104787000120'):
+            return [
+                RouteStop('609-01', 43, None, 7983.46, 18401, '104787000120'),
+                RouteStop('609-02', 43, None, 7983.46, 18504, '104787000120'),
+                RouteStop('609-03', 45, None, 9182.09, 18612, '104787000120')
+            ]
+        return 'Invalid Stop ID'
+      
+    def return_route_stop_by_id_impl(self, stop_id, route_id):
+        return 0

--- a/backend/tests/mock/routes_repository_mock.py
+++ b/backend/tests/mock/routes_repository_mock.py
@@ -1,27 +1,30 @@
 from backend.domain.route.route import Route
 
 class RoutesRepositoryMock:
-
-    def return_all_routes_from_stop_impl(self, stop_id):
-        return 0
-      
-    def return_route_stop_by_id_impl(self, stop_id, route_id):
-        return 0
     
     def return_trips_from_route_impl(self, route_id):
         return 0
     
     def return_one_route_by_id_impl(self, route_id):
+        if(route_id == '609-01'):
+            return Route('609-01', '609', 'Serra Verde/Santa Monica (Principal)', '609-01I', '112845400545', '112845400545')
+        if(route_id == '609-02'):
+            return Route('609-02', '609', 'Serra Verde/Santa Monica (Cid.Admin-Sentido Serra Verde)', '609-02I', '112845400545', '112845400545')
         if(route_id == '609-03'):
             return Route('609-03', '609', 'Serra Verde/Santa Monica (Cid.Admin-Sentido Sta Monica)', '609-03I', '112845400545', '112845400545')
-        else:
-            return 'Invalid route'
+        return 'Invalid Route'
     
     def return_route_conversion_impl(self, route_id):
         return 0
 
     def return_all_routes_impl(self):
-        return 0
+        return [
+            Route('4801A-01', '4801A', 'Jardim Filadelfia/Boa Vista A (Principal)', '4801A-01I', '109207300780', '106312000753'),
+            Route('9550-01', '9550', 'Casa Branca/Sao Francisco Via Est. Jose Candido (Principal)', '9550-01I', '111617000759', '106161701501'),
+            Route('4205-01', '4205', 'Ermelinda/Salgado Filho (Principal)', '4205-01V', '100213500140', '108136000278')
+        ]
 
     def return_route_by_id_impl(self, route_id):
-        return 0       
+        if(route_id == '609-03'):
+            return Route('609-03', '609', 'Serra Verde/Santa Monica (Cid.Admin-Sentido Sta Monica)', '609-03I', '112845400545', '112845400545')
+        return 'Invalid Route'

--- a/backend/tests/unity/test_get_route_impl.py
+++ b/backend/tests/unity/test_get_route_impl.py
@@ -1,0 +1,79 @@
+import unittest
+
+from backend.domain.repositories.route_stop_repository import RouteStopRepository
+from backend.domain.repositories.routes_repository import RoutesRepository
+from backend.tests.mock.routes_repository_mock import RoutesRepositoryMock
+from backend.tests.mock.route_stop_repository_mock import RouteStopRepositoryMock
+from backend.domain.route.get_route_impl import GetRouteImpl
+
+class TestGetRouteImpl(unittest.TestCase):
+
+    def setUp(self):
+        route_stop_repo = RouteStopRepository(RouteStopRepositoryMock())
+        routes_repo = RoutesRepository(RoutesRepositoryMock())
+        self.get_route = GetRouteImpl(routes_repo, route_stop_repo)
+
+    def test_get_routes_from_stop_impl(self):
+        routes_list = self.get_route.get_routes_from_stop_impl('104787000120')
+
+        self.assertEqual(routes_list[0][0], 18401)
+        self.assertEqual(routes_list[1][0], 18504)
+        self.assertEqual(routes_list[2][0], 18612)
+
+        self.assertEqual(routes_list[0][1].__dict__, {
+            'route_id': '609-01', 
+            'route_short_name': '609', 
+            'route_long_name': '', 
+            'shape_id': '', 
+            'initial_stop_id': '', 
+            'final_stop_id': ''})
+        self.assertEqual(routes_list[1][1].__dict__, {
+            'route_id': '609-02', 
+            'route_short_name': '609', 
+            'route_long_name': '', 
+            'shape_id': '', 
+            'initial_stop_id': '', 
+            'final_stop_id': ''})
+        self.assertEqual(routes_list[2][1].__dict__, {
+            'route_id': '609-03', 
+            'route_short_name': '609', 
+            'route_long_name': '', 
+            'shape_id': '', 
+            'initial_stop_id': '', 
+            'final_stop_id': ''})
+
+    def test_get_all_routes_impl(self):
+        routes_list = self.get_route.get_all_routes_impl()
+
+        self.assertEqual(routes_list[0].__dict__, {
+            'route_long_name': 'Jardim Filadelfia/Boa Vista A (Principal)', 
+            'route_id': '4801A-01', 
+            'initial_stop_id': '', 
+            'final_stop_id': '', 
+            'shape_id': '', 
+            'route_short_name': '4801A'})
+        self.assertEqual(routes_list[1].__dict__, {
+            'route_long_name': 'Casa Branca/Sao Francisco Via Est. Jose Candido (Principal)', 
+            'route_id': '9550-01', 
+            'initial_stop_id': '', 
+            'final_stop_id': '',
+            'shape_id': '', 
+            'route_short_name': '9550'})
+        self.assertEqual(routes_list[2].__dict__, {
+            'route_long_name': 'Ermelinda/Salgado Filho (Principal)', 
+            'route_id': '4205-01', 
+            'initial_stop_id': '', 
+            'final_stop_id': '', 
+            'shape_id': '', 
+            'route_short_name': '4205'})
+
+    def test_get_route_by_id_impl(self):
+        route = self.get_route.get_route_by_id_impl('609-03')
+        
+        self.assertEqual(route.__dict__, {
+            'route_id': '609-03', 
+            'route_short_name': '609', 
+            'route_long_name': 'Serra Verde/Santa Monica (Cid.Admin-Sentido Sta Monica)', 
+            'shape_id': '', 
+            'initial_stop_id': '', 
+            'final_stop_id': ''})


### PR DESCRIPTION
- Refatoração do repositório `routes_repo`, para mover funções que acessavam o `route_stop_repo`
- Implementação de novas funções nos mocks de `route_stop_repo` e `route_repo`
- Testes para a classe `get_route_impl`