### PR TITLE
Testes para a classe GetRouteStop

### DIFF
--- a/backend/domain/route_stop/get_route_stop.py
+++ b/backend/domain/route_stop/get_route_stop.py
@@ -1,13 +1,14 @@
 from backend.domain.route_stop.get_route_stop_impl import GetRouteStopImpl
 from backend.domain.repositories.route_stop_repository import RouteStopRepository
+from backend.domain.bus_stop.get_stop import GetStop
 
 class GetRouteStop:
 
-    def __init__(self, route_stop_repo=None):
-        if(route_stop_repo is None):
-            self.impl = GetRouteStopImpl(RouteStopRepository())
+    def __init__(self, route_stop_repo=None, get_stop=None):
+        if(route_stop_repo is None and get_stop is None):
+            self.impl = GetRouteStopImpl(RouteStopRepository(), GetStop())
         else:
-            self.impl = GetRouteStopImpl(route_stop_repo)
+            self.impl = GetRouteStopImpl(route_stop_repo, get_stop)
 
     def get_coordinates_stops_in_route(self, route_id):
         return self.impl.get_coordinates_stops_in_route_impl(route_id)

--- a/backend/domain/route_stop/get_route_stop_impl.py
+++ b/backend/domain/route_stop/get_route_stop_impl.py
@@ -1,14 +1,13 @@
-from backend.domain.bus_stop.get_stop import GetStop
-
 class GetRouteStopImpl:
 
-    def __init__(self, route_stop_repo):
+    def __init__(self, route_stop_repo, get_stop):
         self.route_stop_repo = route_stop_repo
+        self.get_stop = get_stop
 
     def get_coordinates_stops_in_route_impl(self, route_id):
         route_stops_list = self.route_stop_repo.return_all_stops_in_route(route_id)
         stops_list = []
         for rs in route_stops_list:
             stops_list.append(rs.stop_id)
-        stop_coordinates = GetStop().get_stops_coordinates(stops_list)
+        stop_coordinates = self.get_stop.get_stops_coordinates(stops_list)
         return stop_coordinates

--- a/backend/tests/mock/stops_repository_mock.py
+++ b/backend/tests/mock/stops_repository_mock.py
@@ -21,7 +21,7 @@ class StopsRepositoryMock:
         if stops_list == ['10100130600640', '10100446100580']:
             mock_response = [
                 BusStop('10100130600640', 'Estacao Move  Barreiro', -19.97477301931237, -44.0220132041767),
-            BusStop('10100446100580', 'Estacao Move Senai', -19.90639647366688, -43.94348498583775)
+                BusStop('10100446100580', 'Estacao Move Senai', -19.90639647366688, -43.94348498583775)
             ]
         else:
             mock_response = 'Invalid Stop ID'

--- a/backend/tests/unity/test_get_route_stop.py
+++ b/backend/tests/unity/test_get_route_stop.py
@@ -1,0 +1,21 @@
+import unittest
+from backend.domain.bus_stop.get_stop import GetStop
+from backend.tests.mock.stops_repository_mock import StopsRepositoryMock
+from backend.tests.mock.route_stop_repository_mock import RouteStopRepositoryMock
+from backend.domain.repositories.stops_repository import StopsRepository
+from backend.domain.repositories.route_stop_repository import RouteStopRepository
+from backend.domain.route_stop.get_route_stop import GetRouteStop
+
+class TestGetRouteStop(unittest.TestCase):
+
+    def setUp(self):
+        stops_repo = StopsRepository(StopsRepositoryMock())
+        route_stop_repo = RouteStopRepository(RouteStopRepositoryMock())
+        get_stop = GetStop(stops_repo, route_stop_repo)
+        self.get_route_stop = GetRouteStop(route_stop_repo, get_stop)
+
+    def test_get_coordinates_stops_in_route(self):
+        coords = self.get_route_stop.get_coordinates_stops_in_route('609-03')
+        self.assertEqual(coords, [
+            (-44.0220132041767, -19.97477301931237), 
+            (-43.94348498583775, -19.90639647366688)])


### PR DESCRIPTION
- Refatoração das classes `GetRouteStop` e `GetRouteStopImpl` para injetar a dependência de `GetStop`
- Testes para a classe `GetRouteStop`